### PR TITLE
Show capacity of camp_site if tagged.

### DIFF
--- a/l10n/de.js
+++ b/l10n/de.js
@@ -11,6 +11,8 @@ var l10n = {
     "email": "E-Mail",
     "phone": "Telefon",
     "fax": "Fax",
+    "capacity": "Kapazität",
+    "maxtents": "Maximale Anzahl Zelte",
     "address": "Adresse",
     "reservation_required": "Vorreservierung erforderlich!",
     "no_reservation_required": "Vorreservierung nicht möglich!",

--- a/l10n/en.js
+++ b/l10n/en.js
@@ -11,6 +11,8 @@ var l10n = {
    "email": "Email",
    "phone": "Phone",
    "fax": "Fax",
+   "capacity": "Capacity",
+   "maxtents" : "maxtents",
    "address": "Address",
    "reservation_required": "Advance reservation required!",
    "no_reservation_required": "No reservation in advance!",

--- a/l10n/es.js
+++ b/l10n/es.js
@@ -11,6 +11,7 @@ var l10n = {
     "email": "Correo Electrónico",
     "phone": "Teléfono",
     "fax": "Fax",
+    "capacity": "El aforo",
     "address": "Dirección",
     "reservation_required": "Se requiere reserva previa!",
     "no_reservation_required": "Sin reserva previa!",

--- a/l10n/fr.js
+++ b/l10n/fr.js
@@ -11,6 +11,7 @@ var l10n = {
    "email": "Courriel",
    "phone": "Téléphone",
    "fax": "Fax",
+   "capacity": "Capacité",
    "address": "Adresse",
    "reservation_required": "Réservation obligatoire !",
    "no_reservation_required": "Pas de réservation obligatoire !",

--- a/site-feature.js
+++ b/site-feature.js
@@ -175,6 +175,16 @@ function f2html(fdata) {
   
   ihtml += '</p>'
 
+  ihtml += '<p>'
+  if ("capacity" in fdata.properties) {
+    ihtml = ihtml + '<b>'+l10n.capacity+': </b>' + fdata.properties['capacity']+ '<br />';
+  }
+
+  if ("maxtents" in fdata.properties) {
+    ihtml = ihtml + '<b>'+l10n.maxtents+': </b>' + fdata.properties['maxtents']+ '<br />';
+  }
+  ihtml += '</p>'
+
   addr=gen_addr(fdata.properties,'<br />');
   
   if (addr != "") {


### PR DESCRIPTION
It would be nice if the capacity of camp_sites could be shown. This is especially use full for recherche on `group_only` camp sites. Maybe there is a way to only show it for those types of camp sites.

Do I need to add some code to the backend or will this work? I'm unsure.
