### PR TITLE
Fix spelling of "OpenStreetMap"

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Based on:
 * https://turbo87.github.io/sidebar-v2/examples/index.html
 * https://github.com/BenjaminVadant/leaflet-ugeojson
 * https://leafletjs.com/
-* Many icons from [Openstreetmap carto style](https://github.com/gravitystorm/openstreetmap-carto)
+* Many icons from [OpenStreetMap carto style](https://github.com/gravitystorm/openstreetmap-carto)
 * https://github.com/fragaria/address-formatter
 
 Requires backend code available at:

--- a/index.html.de
+++ b/index.html.de
@@ -42,7 +42,7 @@
                     <span class="sidebar-close"><i class="fa fa-caret-left"></i></span>
                 </h1>
                 <div class="legend-content">
-                <p>Eine <a href="http://osm.org" target="_blank" >Openstreetmap</a>
+                <p>Eine <a href="http://osm.org" target="_blank" >OpenStreetMap</a>
                 basierte Weltkarte der Campingplätze.</p>
 
                 <h2>Legende:</h2>
@@ -85,7 +85,7 @@
                 <div id="about content">
                 <p>
                 <b>OpenCampingMap</b> ist eine weltweit verfügbare Karte von Campingplätzen
-		basierend auf Daten aus <a href="http://osm.org" target="_blank">Openstreetmap</a>.
+		basierend auf Daten aus <a href="http://osm.org" target="_blank">OpenStreetMap</a>.
 		</p>
                 <p>
 		Der Quellcode des <a href="https://github.com/giggls/opencampsitemap" target="_blank">Web-Frontends</a>
@@ -97,7 +97,7 @@
                 </p>
 
                 <p>
-		Die verwendeten Daten werden ausschließlich aus Openstreetmap
+		Die verwendeten Daten werden ausschließlich aus OpenStreetMap
 		extrahiert und stündlich aktualisiert.
                 </p>
 		<p>
@@ -122,7 +122,7 @@
 		<p>
 		Informationen zum Tagging von Campingplätzen
                 findet man im
-		<a href="https://wiki.openstreetmap.org/wiki/DE:Tag:tourism%3Dcamp_site" target="_blank">Openstreetmap Wiki</a>
+		<a href="https://wiki.openstreetmap.org/wiki/DE:Tag:tourism%3Dcamp_site" target="_blank">OpenStreetMap Wiki</a>
 		</p>
                 </div>
             </div>

--- a/index.html.en
+++ b/index.html.en
@@ -42,7 +42,7 @@
                     <span class="sidebar-close"><i class="fa fa-caret-left"></i></span>
                 </h1>
                 <div class="legend-content">
-                <p>A map of campgrounds around the world based on <a href="http://osm.org" target="_blank" >Openstreetmap</a>.</p>
+                <p>A map of campgrounds around the world based on <a href="http://osm.org" target="_blank" >OpenStreetMap</a>.</p>
 
                 <h2>Legend:</h2>
                 <h3>Categories:</h3>
@@ -84,7 +84,7 @@
                 <div id="about content">
                 <p>
                 <b>OpenCampingMap</b> is a global map of campgrounds based on
-                data from <a href="http://osm.org" target="_blank">Openstreetmap</a>.
+                data from <a href="http://osm.org" target="_blank">OpenStreetMap</a>.
 		</p>
                 <p>
                 The source code of the Web <a href="https://github.com/giggls/opencampsitemap" target="_blank">frontend</a>
@@ -94,7 +94,7 @@
                 Geggus</a> at GitHub.
                 </p>
                 <p>
-                The data shown here is solely extracted from Openstreetmap
+                The data shown here is solely extracted from OpenStreetMap
                 and updated on an hourly basis.
                 </p>
                 <p>
@@ -117,7 +117,7 @@
 		<p>
 		Information about campsite tagging can be found on the <a
                 href="https://wiki.openstreetmap.org/wiki/Tag:tourism%3Dcamp_site"
-                target="_blank">Openstreetmap Wiki</a>.
+                target="_blank">OpenStreetMap Wiki</a>.
                 </div>
             </div>
         </div>

--- a/index.html.es
+++ b/index.html.es
@@ -42,7 +42,7 @@
                     <span class="sidebar-close"><i class="fa fa-caret-left"></i></span>
                 </h1>
                 <div class="legend-content">
-                <p>Mapa de zonas de acampada alrededor del mundo basado en <a href="http://osm.org" target="_blank" >Openstreetmap</a>.</p>
+                <p>Mapa de zonas de acampada alrededor del mundo basado en <a href="http://osm.org" target="_blank" >OpenStreetMap</a>.</p>
 
                 <h2>Leyenda:</h2>
                 <h3>Categorías:</h3>
@@ -85,14 +85,14 @@
                 <p>
                     <b>OpenCampingMap</b> es un proyecto <a href="https://es.wikipedia.org/wiki/Software_libre_y_de_c%C3%B3digo_abierto" target="_blank">FOSS</a>
                     realizado por <a href="https://wiki.openstreetmap.org/wiki/User:Giggls" target="_blank">Sven Geggus</a>
-                    basado en datos abiertos de <a href="http://osm.org" target="_blank">Openstreetmap</a>.
+                    basado en datos abiertos de <a href="http://osm.org" target="_blank">OpenStreetMap</a>.
                 </p>
                 <p>
                     El código fuente de la <a href="https://github.com/giggls/opencampsitemap" target="_blank">parte frontal de la web</a>
                     así como el <a href="https://github.com/giggls/osmpoidb" target="_blank">backend</a> están disponibles en GitHub.
                 </p>
                 <p>
-                    Los datos mostrados aquí se extraen únicamente de Openstreetmap
+                    Los datos mostrados aquí se extraen únicamente de OpenStreetMap
                     y son actualizados cada hora.
                 </p>
                 <p>
@@ -116,7 +116,7 @@
 		<p>
 		Puedes encontrar información sobre el etiquetado de campings en el <a
                 href="https://wiki.openstreetmap.org/wiki/Tag:tourism%3Dcamp_site"
-                target="_blank">Wiki de Openstreetmap</a>.
+                target="_blank">Wiki de OpenStreetMap</a>.
                 </div>
             </div>
         </div>

--- a/index.html.fr
+++ b/index.html.fr
@@ -42,7 +42,7 @@
                     <span class="sidebar-close"><i class="fa fa-caret-left"></i></span>
                 </h1>
                 <div class="legend-content">
-                <p>Une carte des sites de camping dans le monde basée sur <a href="http://osm.org" target="_blank" >Openstreetmap</a>.</p>
+                <p>Une carte des sites de camping dans le monde basée sur <a href="http://osm.org" target="_blank" >OpenStreetMap</a>.</p>
 
                 <h2>Légende :</h2>
                 <h3>Catégories :</h3>
@@ -88,7 +88,7 @@
                     développé par
                     <a href="https://wiki.openstreetmap.org/wiki/User:Giggls" target="_blank">Sven
                       Geggus</a> et utilisant des données ouvertes issues
-                    d'<a href="http://osm.org" target="_blank">Openstreetmap</a>.</p>
+                    d'<a href="http://osm.org" target="_blank">OpenStreetMap</a>.</p>
                 <p>
                     Le code source de
                     l'<a href="https://github.com/giggls/opencampsitemap" target="_blank">interface web</a>
@@ -96,7 +96,7 @@
                     sont disponibles sur GitHub.
                 </p>
                 <p>
-                    Les données sont intégralement issues d'Openstreetmap et mises
+                    Les données sont intégralement issues d'OpenStreetMap et mises
                     à jour toutes les heures.
                 </p>
                 <p>
@@ -118,7 +118,7 @@
                 </p>
                 <p>
                     La documentation de la description des campings est disponible
-                    sur <a href="https://wiki.openstreetmap.org/wiki/FR:Tag:tourism%3Dcamp_site" target="_blank">le wiki Openstreetmap</a>.
+                    sur <a href="https://wiki.openstreetmap.org/wiki/FR:Tag:tourism%3Dcamp_site" target="_blank">le wiki OpenStreetMap</a>.
                 </div>
             </div>
         </div>

--- a/index.html.ru
+++ b/index.html.ru
@@ -117,7 +117,7 @@
 		<p>
 		Информацию по тегированию кемпингов можно найти на сайте <a
                 href="https://wiki.openstreetmap.org/wiki/RU:Tag:tourism%3Dcamp_site"
-                target="_blank">Openstreetmap Wiki</a>.
+                target="_blank">OpenStreetMap Wiki</a>.
                 </div>
             </div>
         </div>

--- a/taginfo.json
+++ b/taginfo.json
@@ -3,7 +3,7 @@
     "data_url": "https://raw.githubusercontent.com/giggls/opencampsitemap/master/taginfo.json",
     "project": {
         "name": "OpenCampingMap",
-        "description": "A global map of campgrounds based on data from Openstreetmap",
+        "description": "A global map of campgrounds based on data from OpenStreetMap",
         "project_url": "https://opencampingmap.org/",
         "icon_url": "https://opencampingmap.org/favicon.ico",
         "contact_name": "Sven Geggus",


### PR DESCRIPTION
This branch ensures that the spelling of "OpenStreetMap" matches the one on https://openstreetmap.org/.