### PR TITLE
Load and display reviews from Mangrove

### DIFF
--- a/campmap.css
+++ b/campmap.css
@@ -176,8 +176,23 @@ input:checked + .slider:before {
   margin-top: 10px;
 }
 
+#reviews_container .clearfix::after {
+  content: "";
+  clear: both;
+  display: table;
+}
+
 #reviews_container .rating {
   color: yellow;
+  display: inline;
+}
+
+#reviews_container a.open_external {
+  float: right;
+}
+
+#reviews_container .rating,
+#reviews_container a.open_external {
   font-size: 14pt;
 }
 

--- a/campmap.css
+++ b/campmap.css
@@ -141,14 +141,15 @@ input:checked + .slider:before {
   display: block;
 }
 
-/* links to external review portals */
-.review_button {
+/* Full-width button */
+.button {
   text-align: center;
   padding: 5pt;
   border-radius: 5pt;
   border-color: var(--campcolor);
   border-width: 2px;
   border-style: solid;
+  display: block;
 }
 
 /* Reviews from Mangrove */

--- a/campmap.css
+++ b/campmap.css
@@ -162,6 +162,11 @@ input:checked + .slider:before {
   margin-bottom: 0pt;
 }
 
+#reviews_container h4 .powered_by {
+  float: right;
+  color: lightgray;
+}
+
 #reviews_container ul {
   list-style-type: none;
   padding: 0pt;

--- a/campmap.css
+++ b/campmap.css
@@ -189,6 +189,10 @@ input:checked + .slider:before {
   font-size: 14pt;
 }
 
+#reviews_container .meta {
+  margin-top: 6pt;
+}
+
 #reviews_container .meta a {
   float: right;
   font-size: 10pt;

--- a/campmap.css
+++ b/campmap.css
@@ -145,7 +145,6 @@ input:checked + .slider:before {
 .review_button {
   text-align: center;
   padding: 5pt;
-  margin-top: 20pt;
   border-radius: 5pt;
   border-color: var(--campcolor);
   border-width: 2px;
@@ -156,10 +155,6 @@ input:checked + .slider:before {
 
 #reviews_container {
   margin-top: 20pt;
-}
-
-#reviews_container h4 {
-  margin-bottom: 0pt;
 }
 
 #reviews_container h4 .powered_by {

--- a/campmap.css
+++ b/campmap.css
@@ -150,4 +150,38 @@ input:checked + .slider:before {
   border-color: var(--campcolor);
   border-width: 2px;
   border-style: solid;"
+
+/* Reviews from Mangrove */
+
+#reviews_container {
+  margin-top: 20pt;
+}
+
+#reviews_container h4 {
+  margin-bottom: 0pt;
+}
+
+#reviews_container ul {
+  list-style-type: none;
+  padding: 0pt;
+}
+
+#reviews_container .entry {
+  background-color: lightblue;
+  border-radius: 3px;
+  padding: 4pt;
+}
+
+#reviews_container li+li {
+  margin-top: 10px;
+}
+
+#reviews_container .rating {
+  color: yellow;
+  font-size: 14pt;
+}
+
+#reviews_container p {
+  margin-top: 0;
+  margin-bottom: 0rem;
 }

--- a/campmap.css
+++ b/campmap.css
@@ -186,15 +186,13 @@ input:checked + .slider:before {
 #reviews_container .rating {
   color: yellow;
   display: inline;
-}
-
-#reviews_container a.open_external {
-  float: right;
-}
-
-#reviews_container .rating,
-#reviews_container a.open_external {
   font-size: 14pt;
+}
+
+#reviews_container .meta a {
+  float: right;
+  font-size: 10pt;
+  font-style: italic;
 }
 
 #reviews_container p {

--- a/campmap.css
+++ b/campmap.css
@@ -150,6 +150,7 @@ input:checked + .slider:before {
   border-color: var(--campcolor);
   border-width: 2px;
   border-style: solid;
+}
 
 /* Reviews from Mangrove */
 

--- a/campmap.css
+++ b/campmap.css
@@ -169,7 +169,7 @@ input:checked + .slider:before {
 }
 
 #reviews_container .entry {
-  background-color: lightblue;
+  background-color: #ddddff;
   border-radius: 3px;
   padding: 4pt;
 }

--- a/campmap.css
+++ b/campmap.css
@@ -149,7 +149,7 @@ input:checked + .slider:before {
   border-radius: 5pt;
   border-color: var(--campcolor);
   border-width: 2px;
-  border-style: solid;"
+  border-style: solid;
 
 /* Reviews from Mangrove */
 

--- a/campmap.css
+++ b/campmap.css
@@ -160,7 +160,7 @@ input:checked + .slider:before {
 
 #reviews_container h4 .powered_by {
   float: right;
-  color: lightgray;
+  color: gray;
 }
 
 #reviews_container ul {
@@ -185,7 +185,7 @@ input:checked + .slider:before {
 }
 
 #reviews_container .rating {
-  color: yellow;
+  color: #b8860b;
   display: inline;
   font-size: 14pt;
 }

--- a/campmap.css
+++ b/campmap.css
@@ -203,3 +203,8 @@ input:checked + .slider:before {
   margin-top: 0;
   margin-bottom: 0rem;
 }
+
+#reviews_container .loading_or_no_reviews {
+  text-align: center;
+  margin-top: 10pt;
+}

--- a/campmap.js
+++ b/campmap.js
@@ -201,6 +201,7 @@ var gps = new L.Control.Gps({
 function updateSidebars(featureData) {
   f2html(featureData);
   f2bugInfo(featureData);
+  loadReviews(featureData);
   var cat;
   var private = false;
   if ('access' in featureData.properties) {

--- a/index.html.de
+++ b/index.html.de
@@ -144,6 +144,7 @@
     <script src="geocoder/Control.Geocoder.js"></script>
     <script src="leaflet-plugins/leaflet-gps.js"></script>
     <script src="address-formatter@2.0.5.js"></script>
+    <script src="reviews.js"></script>
     <script src="campmap.js"></script>
 </body>
 </html>

--- a/index.html.en
+++ b/index.html.en
@@ -138,6 +138,7 @@
     <script src="geocoder/Control.Geocoder.js"></script>
     <script src="leaflet-plugins/leaflet-gps.js"></script>
     <script src="address-formatter@2.0.5.js"></script>
+    <script src="reviews.js"></script>
     <script src="campmap.js"></script>
 </body>
 </html>

--- a/index.html.es
+++ b/index.html.es
@@ -137,6 +137,7 @@
     <script src="geocoder/Control.Geocoder.js"></script>
     <script src="leaflet-plugins/leaflet-gps.js"></script>
     <script src="address-formatter@2.0.5.js"></script>
+    <script src="reviews.js"></script>
     <script src="campmap.js"></script>
 </body>
 </html>

--- a/index.html.fr
+++ b/index.html.fr
@@ -139,6 +139,7 @@
     <script src="geocoder/Control.Geocoder.js"></script>
     <script src="leaflet-plugins/leaflet-gps.js"></script>
     <script src="address-formatter@2.0.5.js"></script>
+    <script src="reviews.js"></script>
     <script src="campmap.js"></script>
 </body>
 </html>

--- a/index.html.ru
+++ b/index.html.ru
@@ -138,6 +138,7 @@
     <script src="geocoder/Control.Geocoder.js"></script>
     <script src="leaflet-plugins/leaflet-gps.js"></script>
     <script src="address-formatter@2.0.5.js"></script>
+    <script src="reviews.js"></script>
     <script src="campmap.js"></script>
 </body>
 </html>

--- a/l10n/de.js
+++ b/l10n/de.js
@@ -52,7 +52,8 @@ var l10n = {
   "site_contains": 'Platz enthält weitere Objekte, die mit <b>tourism&nbsp;=&nbsp;camp_site</b> getaggt wurden',
   "add_review": 'Bewertung hinzufügen',
   "reviews": 'Bewertungen',
-  "default_reviewer_name": 'Anonym'
+  "default_reviewer_name": 'Anonym',
+  "loading_reviews": 'Laden, bitte warten...'
 };
 
 /* 

--- a/l10n/de.js
+++ b/l10n/de.js
@@ -53,7 +53,8 @@ var l10n = {
   "add_review": 'Bewertung hinzufügen',
   "reviews": 'Bewertungen',
   "default_reviewer_name": 'Anonym',
-  "loading_reviews": 'Laden, bitte warten...'
+  "loading_reviews": 'Laden, bitte warten...',
+  "no_reviews_yet": 'Noch keine Bewertungen vorhanden.'
 };
 
 /* 

--- a/l10n/de.js
+++ b/l10n/de.js
@@ -50,7 +50,8 @@ var l10n = {
   "uselesssiterel": 'Nicht benötigte Site-Relation',
   "site_inside": 'Platz liegt innerhalb eines Objekts, das mit <b>tourism&nbsp;=&nbsp;camp_site</b> getaggt wurde',
   "site_contains": 'Platz enthält weitere Objekte, die mit <b>tourism&nbsp;=&nbsp;camp_site</b> getaggt wurden',
-  "review": 'Bewertung hinzufügen/ansehen'
+  "add_review": 'Bewertung hinzufügen',
+  "reviews": 'Bewertungen'
 };
 
 /* 

--- a/l10n/de.js
+++ b/l10n/de.js
@@ -54,7 +54,8 @@ var l10n = {
   "reviews": 'Bewertungen',
   "default_reviewer_name": 'Anonym',
   "loading_reviews": 'Laden, bitte warten...',
-  "no_reviews_yet": 'Noch keine Bewertungen vorhanden.'
+  "no_reviews_yet": 'Noch keine Bewertungen vorhanden.',
+  "powered_by": 'unterstützt durch'
 };
 
 /* 

--- a/l10n/de.js
+++ b/l10n/de.js
@@ -51,7 +51,8 @@ var l10n = {
   "site_inside": 'Platz liegt innerhalb eines Objekts, das mit <b>tourism&nbsp;=&nbsp;camp_site</b> getaggt wurde',
   "site_contains": 'Platz enthält weitere Objekte, die mit <b>tourism&nbsp;=&nbsp;camp_site</b> getaggt wurden',
   "add_review": 'Bewertung hinzufügen',
-  "reviews": 'Bewertungen'
+  "reviews": 'Bewertungen',
+  "default_reviewer_name": 'Anonym'
 };
 
 /* 

--- a/l10n/en.js
+++ b/l10n/en.js
@@ -52,7 +52,8 @@ var l10n = {
   "site_contains": 'Site contains other objects tagged <b>tourism&nbsp;=&nbsp;camp_site</b>',
   "add_review": 'Add review',
   "reviews": 'Reviews',
-  "default_reviewer_name": 'Anonymous'
+  "default_reviewer_name": 'Anonymous',
+  "loading_reviews": 'Loading, please wait...'
 };
 
 /* 

--- a/l10n/en.js
+++ b/l10n/en.js
@@ -50,7 +50,8 @@ var l10n = {
   "uselesssiterel": 'Site-relation not needed',
   "site_inside": 'Site located inside other object tagged <b>tourism&nbsp;=&nbsp;camp_site</b>',
   "site_contains": 'Site contains other objects tagged <b>tourism&nbsp;=&nbsp;camp_site</b>',
-  "review": 'Add/view review'
+  "add_review": 'Add review',
+  "reviews": 'reviews'
 };
 
 /* 

--- a/l10n/en.js
+++ b/l10n/en.js
@@ -51,7 +51,8 @@ var l10n = {
   "site_inside": 'Site located inside other object tagged <b>tourism&nbsp;=&nbsp;camp_site</b>',
   "site_contains": 'Site contains other objects tagged <b>tourism&nbsp;=&nbsp;camp_site</b>',
   "add_review": 'Add review',
-  "reviews": 'Reviews'
+  "reviews": 'Reviews',
+  "default_reviewer_name": 'Anonymous'
 };
 
 /* 

--- a/l10n/en.js
+++ b/l10n/en.js
@@ -53,7 +53,8 @@ var l10n = {
   "add_review": 'Add review',
   "reviews": 'Reviews',
   "default_reviewer_name": 'Anonymous',
-  "loading_reviews": 'Loading, please wait...'
+  "loading_reviews": 'Loading, please wait...',
+  "no_reviews_yet": 'No reviews yet.'
 };
 
 /* 

--- a/l10n/en.js
+++ b/l10n/en.js
@@ -51,7 +51,7 @@ var l10n = {
   "site_inside": 'Site located inside other object tagged <b>tourism&nbsp;=&nbsp;camp_site</b>',
   "site_contains": 'Site contains other objects tagged <b>tourism&nbsp;=&nbsp;camp_site</b>',
   "add_review": 'Add review',
-  "reviews": 'reviews'
+  "reviews": 'Reviews'
 };
 
 /* 

--- a/l10n/en.js
+++ b/l10n/en.js
@@ -54,7 +54,8 @@ var l10n = {
   "reviews": 'Reviews',
   "default_reviewer_name": 'Anonymous',
   "loading_reviews": 'Loading, please wait...',
-  "no_reviews_yet": 'No reviews yet.'
+  "no_reviews_yet": 'No reviews yet.',
+  "powered_by": 'powered by'
 };
 
 /* 

--- a/l10n/es.js
+++ b/l10n/es.js
@@ -51,7 +51,8 @@ var l10n = {
   "site_inside": 'Site located inside other object tagged <b>tourism&nbsp;=&nbsp;camp_site</b>',
   "site_contains": 'Site contains other objects tagged <b>tourism&nbsp;=&nbsp;camp_site</b>',
   "add_review": 'Add review',
-  "reviews": 'reviews'
+  "reviews": 'reviews',
+  "default_reviewer_name": 'Anonymous'
 };
 
 /*

--- a/l10n/es.js
+++ b/l10n/es.js
@@ -50,7 +50,8 @@ var l10n = {
   "uselesssiterel": 'Relación tipo Site innecesaria',
   "site_inside": 'Site located inside other object tagged <b>tourism&nbsp;=&nbsp;camp_site</b>',
   "site_contains": 'Site contains other objects tagged <b>tourism&nbsp;=&nbsp;camp_site</b>',
-  "review": 'Add/view review'
+  "add_review": 'Add review',
+  "reviews": 'reviews'
 };
 
 /*

--- a/l10n/es.js
+++ b/l10n/es.js
@@ -52,7 +52,8 @@ var l10n = {
   "site_contains": 'Site contains other objects tagged <b>tourism&nbsp;=&nbsp;camp_site</b>',
   "add_review": 'Add review',
   "reviews": 'reviews',
-  "default_reviewer_name": 'Anonymous'
+  "default_reviewer_name": 'Anonymous',
+  "loading_reviews": 'Loading, please wait...'
 };
 
 /*

--- a/l10n/es.js
+++ b/l10n/es.js
@@ -53,7 +53,8 @@ var l10n = {
   "add_review": 'Add review',
   "reviews": 'reviews',
   "default_reviewer_name": 'Anonymous',
-  "loading_reviews": 'Loading, please wait...'
+  "loading_reviews": 'Loading, please wait...',
+  "no_reviews_yet": 'No reviews yet.'
 };
 
 /*

--- a/l10n/es.js
+++ b/l10n/es.js
@@ -54,7 +54,8 @@ var l10n = {
   "reviews": 'reviews',
   "default_reviewer_name": 'Anonymous',
   "loading_reviews": 'Loading, please wait...',
-  "no_reviews_yet": 'No reviews yet.'
+  "no_reviews_yet": 'No reviews yet.',
+  "powered_by": 'powered by'
 };
 
 /*

--- a/l10n/fr.js
+++ b/l10n/fr.js
@@ -51,7 +51,8 @@ var l10n = {
   "site_inside": 'Site located inside other object tagged <b>tourism&nbsp;=&nbsp;camp_site</b>',
   "site_contains": 'Site contains other objects tagged <b>tourism&nbsp;=&nbsp;camp_site</b>',
   "add_review": 'Add review',
-  "reviews": 'reviews'
+  "reviews": 'reviews',
+  "default_reviewer_name": 'Anonymous'
 };
 
 /*

--- a/l10n/fr.js
+++ b/l10n/fr.js
@@ -50,7 +50,8 @@ var l10n = {
   "uselesssiterel": 'Relation de site pas nécessaires.',
   "site_inside": 'Site located inside other object tagged <b>tourism&nbsp;=&nbsp;camp_site</b>',
   "site_contains": 'Site contains other objects tagged <b>tourism&nbsp;=&nbsp;camp_site</b>',
-  "review": 'Add/view review'
+  "add_review": 'Add review',
+  "reviews": 'reviews'
 };
 
 /*

--- a/l10n/fr.js
+++ b/l10n/fr.js
@@ -52,7 +52,8 @@ var l10n = {
   "site_contains": 'Site contains other objects tagged <b>tourism&nbsp;=&nbsp;camp_site</b>',
   "add_review": 'Add review',
   "reviews": 'reviews',
-  "default_reviewer_name": 'Anonymous'
+  "default_reviewer_name": 'Anonymous',
+  "loading_reviews": 'Loading, please wait...'
 };
 
 /*

--- a/l10n/fr.js
+++ b/l10n/fr.js
@@ -53,7 +53,8 @@ var l10n = {
   "add_review": 'Add review',
   "reviews": 'reviews',
   "default_reviewer_name": 'Anonymous',
-  "loading_reviews": 'Loading, please wait...'
+  "loading_reviews": 'Loading, please wait...',
+  "no_reviews_yet": 'No reviews yet.'
 };
 
 /*

--- a/l10n/fr.js
+++ b/l10n/fr.js
@@ -54,7 +54,8 @@ var l10n = {
   "reviews": 'reviews',
   "default_reviewer_name": 'Anonymous',
   "loading_reviews": 'Loading, please wait...',
-  "no_reviews_yet": 'No reviews yet.'
+  "no_reviews_yet": 'No reviews yet.',
+  "powered_by": 'powered by'
 };
 
 /*

--- a/l10n/ru.js
+++ b/l10n/ru.js
@@ -51,7 +51,8 @@ var l10n = {
   "site_inside": 'Site located inside other object tagged <b>tourism&nbsp;=&nbsp;camp_site</b>',
   "site_contains": 'Site contains other objects tagged <b>tourism&nbsp;=&nbsp;camp_site</b>',
   "add_review": 'Add review',
-  "reviews": 'reviews'
+  "reviews": 'reviews',
+  "default_reviewer_name": 'Anonymous'
 };
 
 /* 

--- a/l10n/ru.js
+++ b/l10n/ru.js
@@ -50,7 +50,8 @@ var l10n = {
   "uselesssiterel": 'Site-relation not needed',
   "site_inside": 'Site located inside other object tagged <b>tourism&nbsp;=&nbsp;camp_site</b>',
   "site_contains": 'Site contains other objects tagged <b>tourism&nbsp;=&nbsp;camp_site</b>',
-  "review": 'Add/view review'
+  "add_review": 'Add review',
+  "reviews": 'reviews'
 };
 
 /* 

--- a/l10n/ru.js
+++ b/l10n/ru.js
@@ -53,7 +53,8 @@ var l10n = {
   "add_review": 'Add review',
   "reviews": 'reviews',
   "default_reviewer_name": 'Anonymous',
-  "loading_reviews": 'Loading, please wait...'
+  "loading_reviews": 'Loading, please wait...',
+  "no_reviews_yet": 'No reviews yet.'
 };
 
 /* 

--- a/l10n/ru.js
+++ b/l10n/ru.js
@@ -52,7 +52,8 @@ var l10n = {
   "site_contains": 'Site contains other objects tagged <b>tourism&nbsp;=&nbsp;camp_site</b>',
   "add_review": 'Add review',
   "reviews": 'reviews',
-  "default_reviewer_name": 'Anonymous'
+  "default_reviewer_name": 'Anonymous',
+  "loading_reviews": 'Loading, please wait...'
 };
 
 /* 

--- a/l10n/ru.js
+++ b/l10n/ru.js
@@ -54,7 +54,8 @@ var l10n = {
   "reviews": 'reviews',
   "default_reviewer_name": 'Anonymous',
   "loading_reviews": 'Loading, please wait...',
-  "no_reviews_yet": 'No reviews yet.'
+  "no_reviews_yet": 'No reviews yet.',
+  "powered_by": 'powered by'
 };
 
 /* 

--- a/reviews.js
+++ b/reviews.js
@@ -1,0 +1,74 @@
+/*
+  Integration of Mangrove reviews into OpenCampingMap
+*/
+// The ID of the DIV that displays the reviews.
+const containerId = 'reviews_container';
+
+function loadReviews(featureData) {
+  if (!("name" in featureData.properties)) {
+    // Only camping places with names can have reviews.
+    return;
+  }
+
+  const coordinate = `${featureData.geometry.coordinates[1]},${featureData.geometry.coordinates[0]}`
+  const uncertainty = 50;
+  const sub = encodeURIComponent(`geo:${coordinate}?q=${coordinate}&u=${uncertainty}`);
+
+  const q = encodeURIComponent(featureData.properties.name);
+
+  const url = `https://api.mangrove.reviews/reviews?q=${q}&sub=${sub}`;
+
+  var request = new XMLHttpRequest();
+  request.open('GET', url);
+  request.addEventListener('load', function (event) {
+    if (request.status >= 200 && request.status < 300) {
+      const json = JSON.parse(request.responseText);
+      displayReviews(json);
+    } else {
+      console.warn(gcsr.statusText, gcsr.responseText);
+    }
+  });
+  request.send();
+}
+
+function starsForRating(rating) {
+  if (rating == 100) {
+    return '★★★★★';
+  } else if (rating >= 80) {
+    return '★★★★☆';
+  } else if (rating >= 60) {
+    return '★★★☆☆';
+  } else if (rating >= 40) {
+    return '★★☆☆☆';
+  } else if (rating >= 20) {
+    return '★☆☆☆☆';
+  } else {
+    return '☆☆☆☆☆';
+  }
+}
+
+function htmlForReview(json) {
+  var html = '<li><div class="entry">';
+
+  html += `<div class="rating">${starsForRating(json.payload.rating)}</div>`;
+
+  // Ensure that line breaks are preserved.
+  const opinion = json.payload.opinion.replace(/(?:\r\n|\r|\n)/g, '<br>');
+  html += `<p>${opinion}</p>`;
+
+  html += '</div></li>';
+
+  return html;
+}
+
+function displayReviews(json) {
+  var html = '<h4>Reviews</h4>';
+
+  if (json.reviews.length == 0) {
+    html += '<p>No reviews yet.</p>';
+  } else {
+    html += `<ul>${json.reviews.map(htmlForReview)}</ul>`;
+  }
+
+  document.getElementById(containerId).innerHTML = html;
+}

--- a/reviews.js
+++ b/reviews.js
@@ -25,7 +25,7 @@ function loadReviews(featureData) {
       const json = JSON.parse(request.responseText);
       displayReviews(json);
     } else {
-      console.warn(gcsr.statusText, gcsr.responseText);
+      console.warn(request.statusText, request.responseText);
     }
   });
   request.send();

--- a/reviews.js
+++ b/reviews.js
@@ -7,6 +7,10 @@ const containerId = 'reviews_container';
 // URL of the Mangrove UI
 const mangroveHomepageURL = 'https://mangrove.reviews/';
 
+// The uncertainty to use when searching for Mangrove reviews.
+// See: https://mangrove.reviews/standard#mangrove-core-uri-schemes
+const uncertainty = 50;
+
 function loadReviews(featureData) {
   if (!("name" in featureData.properties)) {
     // Only camping places with names can have reviews.
@@ -16,7 +20,6 @@ function loadReviews(featureData) {
   showLoading();
 
   const coordinate = `${featureData.geometry.coordinates[1]},${featureData.geometry.coordinates[0]}`
-  const uncertainty = 50;
   const sub = encodeURIComponent(`geo:${coordinate}?q=${coordinate}&u=${uncertainty}`);
 
   const q = encodeURIComponent(featureData.properties.name);

--- a/reviews.js
+++ b/reviews.js
@@ -4,6 +4,9 @@
 // The ID of the DIV that displays the reviews.
 const containerId = 'reviews_container';
 
+// URL of the Mangrove UI
+const mangroveHomepageURL = 'https://mangrove.reviews/';
+
 function loadReviews(featureData) {
   if (!("name" in featureData.properties)) {
     // Only camping places with names can have reviews.
@@ -38,7 +41,9 @@ function showLoading() {
 }
 
 function htmlForHeader() {
-  return `<h4 class="clearfix">${l10n.reviews}:<span class="powered_by">${l10n.powered_by} Mangrove</span></h4>`;
+  const mangroveLink = `<a href="${mangroveHomepageURL}" target="_blank">Mangrove</a>`;
+
+  return `<h4 class="clearfix">${l10n.reviews}:<span class="powered_by">${l10n.powered_by} ${mangroveLink}</span></h4>`;
 }
 
 function starsForRating(rating) {

--- a/reviews.js
+++ b/reviews.js
@@ -50,7 +50,10 @@ function starsForRating(rating) {
 function htmlForReview(json) {
   var html = '<li><div class="entry">';
 
-  html += `<div class="rating">${starsForRating(json.payload.rating)}</div>`;
+  const rating = `<div class="rating">${starsForRating(json.payload.rating)}</div>`;
+  const viewOnMangroveURL = `https://mangrove.reviews/list?signature=${json.signature}`;
+  const openMangroveLink = `<a class="open_external" href="${viewOnMangroveURL}" target="_blank">🔗</a>`
+  html += `<div class="clearfix">${rating}${openMangroveLink}</div>`;
 
   // Ensure that line breaks are preserved.
   const opinion = json.payload.opinion.replace(/(?:\r\n|\r|\n)/g, '<br>');

--- a/reviews.js
+++ b/reviews.js
@@ -43,7 +43,7 @@ function showLoading() {
 function htmlForHeader() {
   const mangroveLink = `<a href="${mangroveHomepageURL}" target="_blank">Mangrove</a>`;
 
-  return `<h4 class="clearfix">${l10n.reviews}:<span class="powered_by">${l10n.powered_by} ${mangroveLink}</span></h4>`;
+  return `<h4 class="clearfix">${l10n.reviews}<span class="powered_by">${l10n.powered_by} ${mangroveLink}</span></h4>`;
 }
 
 function starsForRating(rating) {

--- a/reviews.js
+++ b/reviews.js
@@ -17,7 +17,7 @@ function loadReviews(featureData) {
     return;
   }
 
-  showLoading();
+  showLoading(featureData);
 
   const coordinate = `${featureData.geometry.coordinates[1]},${featureData.geometry.coordinates[0]}`
   const sub = encodeURIComponent(`geo:${coordinate}?q=${coordinate}&u=${uncertainty}`);
@@ -39,8 +39,10 @@ function loadReviews(featureData) {
   request.send();
 }
 
-function showLoading() {
-  document.getElementById(containerId).innerHTML = `${htmlForHeader()}<p>${l10n.loading_reviews}</p>`;
+function showLoading(featureData) {
+  const addReviewButton = htmlForAddReviewButton(featureData);
+
+  document.getElementById(containerId).innerHTML = `${htmlForHeader()}${addReviewButton}<p class="loading_or_no_reviews">${l10n.loading_reviews}</p>`;
 }
 
 function htmlForHeader() {
@@ -129,7 +131,7 @@ function displayReviews(featureData, json) {
   html += htmlForAddReviewButton(featureData);
 
   if (json.reviews.length == 0) {
-    html += `<p>${l10n.no_reviews_yet}</p>`;
+    html += `<p class="loading_or_no_reviews">${l10n.no_reviews_yet}</p>`;
   } else {
     html += `<ul>${json.reviews.map(htmlForReview)}</ul>`;
   }

--- a/reviews.js
+++ b/reviews.js
@@ -5,7 +5,7 @@
 const containerId = 'reviews_container';
 
 // HTML that is always displayed on top of the reviews section of the sidebar.
-const header = `<h4>${l10n.reviews}:</h4>`;
+const header = `<h4 class="clearfix">${l10n.reviews}:<span class="powered_by">${l10n.powered_by} Mangrove</span></h4>`;
 
 function loadReviews(featureData) {
   if (!("name" in featureData.properties)) {

--- a/reviews.js
+++ b/reviews.js
@@ -34,7 +34,7 @@ function loadReviews(featureData) {
 }
 
 function showLoading() {
-  document.getElementById(containerId).innerHTML = `<h4>${l10n.reviews}</h4><p>Loading, please wait...</p>`;
+  document.getElementById(containerId).innerHTML = `<h4>${l10n.reviews}</h4><p>${l10n.loading_reviews}</p>`;
 }
 
 function starsForRating(rating) {

--- a/reviews.js
+++ b/reviews.js
@@ -4,9 +4,6 @@
 // The ID of the DIV that displays the reviews.
 const containerId = 'reviews_container';
 
-// HTML that is always displayed on top of the reviews section of the sidebar.
-const header = `<h4 class="clearfix">${l10n.reviews}:<span class="powered_by">${l10n.powered_by} Mangrove</span></h4>`;
-
 function loadReviews(featureData) {
   if (!("name" in featureData.properties)) {
     // Only camping places with names can have reviews.
@@ -37,7 +34,11 @@ function loadReviews(featureData) {
 }
 
 function showLoading() {
-  document.getElementById(containerId).innerHTML = `${header}<p>${l10n.loading_reviews}</p>`;
+  document.getElementById(containerId).innerHTML = `${htmlForHeader()}<p>${l10n.loading_reviews}</p>`;
+}
+
+function htmlForHeader() {
+  return `<h4 class="clearfix">${l10n.reviews}:<span class="powered_by">${l10n.powered_by} Mangrove</span></h4>`;
 }
 
 function starsForRating(rating) {
@@ -105,7 +106,7 @@ function nameForMetadata(metadataJSON) {
 }
 
 function displayReviews(json) {
-  var html = header;
+  var html = htmlForHeader();
 
   if (json.reviews.length == 0) {
     html += `<p>${l10n.no_reviews_yet}</p>`;

--- a/reviews.js
+++ b/reviews.js
@@ -105,7 +105,7 @@ function displayReviews(json) {
   var html = `<h4>${l10n.reviews}:</h4>`;
 
   if (json.reviews.length == 0) {
-    html += '<p>No reviews yet.</p>';
+    html += `<p>${l10n.no_reviews_yet}</p>`;
   } else {
     html += `<ul>${json.reviews.map(htmlForReview)}</ul>`;
   }

--- a/reviews.js
+++ b/reviews.js
@@ -32,19 +32,13 @@ function loadReviews(featureData) {
 }
 
 function starsForRating(rating) {
-  if (rating == 100) {
-    return '★★★★★';
-  } else if (rating >= 80) {
-    return '★★★★☆';
-  } else if (rating >= 60) {
-    return '★★★☆☆';
-  } else if (rating >= 40) {
-    return '★★☆☆☆';
-  } else if (rating >= 20) {
-    return '★☆☆☆☆';
-  } else {
-    return '☆☆☆☆☆';
-  }
+  let emptyStar = '☆';
+  let fullStar = '★';
+
+  let numberOfFullStars = Math.round(rating / 20);
+  let numberOfEmptyStars = 5 - numberOfFullStars;
+
+  return `${fullStar.repeat(numberOfFullStars)}${emptyStar.repeat(numberOfEmptyStars)}`;
 }
 
 function htmlForReview(json) {

--- a/reviews.js
+++ b/reviews.js
@@ -49,8 +49,11 @@ function htmlForReview(json) {
 
   html += `<div class="rating">${starsForRating(json.payload.rating)}</div>`;
 
-  // Ensure that line breaks are preserved.
-  const opinion = json.payload.opinion.replace(/(?:\r\n|\r|\n)/g, '<br>');
+  // Trim line breaks from the start and from the end of the string.
+  const trimmedOpinion = json.payload.opinion.replace(/^\s+|\s+$/g, '');
+
+  // Convert line breaks to `<br>` elements.
+  const opinion = trimmedOpinion.replace(/(?:\r\n|\r|\n)/g, '<br>');
   html += `<p>${opinion}</p>`;
 
   const viewOnMangroveURL = `https://mangrove.reviews/list?signature=${json.signature}`;

--- a/reviews.js
+++ b/reviews.js
@@ -31,7 +31,7 @@ function loadReviews(featureData) {
   request.addEventListener('load', function (event) {
     if (request.status >= 200 && request.status < 300) {
       const json = JSON.parse(request.responseText);
-      displayReviews(json);
+      displayReviews(featureData, json);
     } else {
       console.warn(request.statusText, request.responseText);
     }
@@ -47,6 +47,16 @@ function htmlForHeader() {
   const mangroveLink = `<a href="${mangroveHomepageURL}" target="_blank">Mangrove</a>`;
 
   return `<h4 class="clearfix">${l10n.reviews}<span class="powered_by">${l10n.powered_by} ${mangroveLink}</span></h4>`;
+}
+
+function htmlForAddReviewButton(featureData) {
+  const coordinate = `${featureData.geometry.coordinates[1]},${featureData.geometry.coordinates[0]}`;
+  const siteName = featureData.properties.name;
+  const geoURI = `geo:${coordinate}?q=${siteName}&u=${uncertainty}`;
+  const sub = encodeURIComponent(geoURI);
+  const mangroveSearchURL = `https://mangrove.reviews/search?sub=${sub}`;
+
+  return `<div id="review" class="review_button">\n<a href="${mangroveSearchURL}" target="_blank">${l10n.add_review}</a></div>`;
 }
 
 function starsForRating(rating) {
@@ -113,8 +123,10 @@ function nameForMetadata(metadataJSON) {
   }
 }
 
-function displayReviews(json) {
+function displayReviews(featureData, json) {
   var html = htmlForHeader();
+
+  html += htmlForAddReviewButton(featureData);
 
   if (json.reviews.length == 0) {
     html += `<p>${l10n.no_reviews_yet}</p>`;

--- a/reviews.js
+++ b/reviews.js
@@ -4,6 +4,9 @@
 // The ID of the DIV that displays the reviews.
 const containerId = 'reviews_container';
 
+// HTML that is always displayed on top of the reviews section of the sidebar.
+const header = `<h4>${l10n.reviews}:</h4>`;
+
 function loadReviews(featureData) {
   if (!("name" in featureData.properties)) {
     // Only camping places with names can have reviews.
@@ -34,7 +37,7 @@ function loadReviews(featureData) {
 }
 
 function showLoading() {
-  document.getElementById(containerId).innerHTML = `<h4>${l10n.reviews}:</h4><p>${l10n.loading_reviews}</p>`;
+  document.getElementById(containerId).innerHTML = `${header}<p>${l10n.loading_reviews}</p>`;
 }
 
 function starsForRating(rating) {
@@ -102,7 +105,7 @@ function nameForMetadata(metadataJSON) {
 }
 
 function displayReviews(json) {
-  var html = `<h4>${l10n.reviews}:</h4>`;
+  var html = header;
 
   if (json.reviews.length == 0) {
     html += `<p>${l10n.no_reviews_yet}</p>`;

--- a/reviews.js
+++ b/reviews.js
@@ -4,9 +4,6 @@
 // The ID of the DIV that displays the reviews.
 const containerId = 'reviews_container';
 
-// The name that is displayed in case the review author did not provide any name.
-const defaultReviewerName = 'Anonymous';
-
 function loadReviews(featureData) {
   if (!("name" in featureData.properties)) {
     // Only camping places with names can have reviews.
@@ -100,7 +97,7 @@ function nameForMetadata(metadataJSON) {
     // Only the fullname is present.
     return fullname;
   } else {
-    return defaultReviewerName;
+    return l10n.default_reviewer_name;
   }
 }
 

--- a/reviews.js
+++ b/reviews.js
@@ -13,6 +13,8 @@ function loadReviews(featureData) {
     return;
   }
 
+  showLoading();
+
   const coordinate = `${featureData.geometry.coordinates[1]},${featureData.geometry.coordinates[0]}`
   const uncertainty = 50;
   const sub = encodeURIComponent(`geo:${coordinate}?q=${coordinate}&u=${uncertainty}`);
@@ -32,6 +34,10 @@ function loadReviews(featureData) {
     }
   });
   request.send();
+}
+
+function showLoading() {
+  document.getElementById(containerId).innerHTML = '<h4>Reviews</h4><p>Loading, please wait...</p>';
 }
 
 function starsForRating(rating) {

--- a/reviews.js
+++ b/reviews.js
@@ -58,7 +58,7 @@ function htmlForAddReviewButton(featureData) {
   const sub = encodeURIComponent(geoURI);
   const mangroveSearchURL = `https://mangrove.reviews/search?sub=${sub}`;
 
-  return `<div id="review" class="review_button">\n<a href="${mangroveSearchURL}" target="_blank">${l10n.add_review}</a></div>`;
+  return `<a href="${mangroveSearchURL}" class="button" target="_blank">${l10n.add_review}</a></div>`;
 }
 
 function starsForRating(rating) {

--- a/reviews.js
+++ b/reviews.js
@@ -34,7 +34,7 @@ function loadReviews(featureData) {
 }
 
 function showLoading() {
-  document.getElementById(containerId).innerHTML = `<h4>${l10n.reviews}</h4><p>${l10n.loading_reviews}</p>`;
+  document.getElementById(containerId).innerHTML = `<h4>${l10n.reviews}:</h4><p>${l10n.loading_reviews}</p>`;
 }
 
 function starsForRating(rating) {

--- a/reviews.js
+++ b/reviews.js
@@ -44,18 +44,25 @@ function starsForRating(rating) {
 function htmlForReview(json) {
   var html = '<li><div class="entry">';
 
-  const rating = `<div class="rating">${starsForRating(json.payload.rating)}</div>`;
-  const viewOnMangroveURL = `https://mangrove.reviews/list?signature=${json.signature}`;
-  const openMangroveLink = `<a class="open_external" href="${viewOnMangroveURL}" target="_blank">🔗</a>`
-  html += `<div class="clearfix">${rating}${openMangroveLink}</div>`;
+  html += `<div class="rating">${starsForRating(json.payload.rating)}</div>`;
 
   // Ensure that line breaks are preserved.
   const opinion = json.payload.opinion.replace(/(?:\r\n|\r|\n)/g, '<br>');
   html += `<p>${opinion}</p>`;
 
+  const viewOnMangroveURL = `https://mangrove.reviews/list?signature=${json.signature}`;
+  const dateAsString = dateStringForUnixTimestamp(json.payload.iat);
+  html += `<div class="meta clearfix"><a href="${viewOnMangroveURL}" target="_blank">${dateAsString}</a></div>`;
+
   html += '</div></li>';
 
   return html;
+}
+
+function dateStringForUnixTimestamp(unixTimestamp) {
+  const date = new Date(unixTimestamp * 1000);
+
+  return date.toLocaleDateString();
 }
 
 function displayReviews(json) {

--- a/reviews.js
+++ b/reviews.js
@@ -37,7 +37,7 @@ function loadReviews(featureData) {
 }
 
 function showLoading() {
-  document.getElementById(containerId).innerHTML = '<h4>Reviews</h4><p>Loading, please wait...</p>';
+  document.getElementById(containerId).innerHTML = `<h4>${l10n.reviews}</h4><p>Loading, please wait...</p>`;
 }
 
 function starsForRating(rating) {
@@ -105,7 +105,7 @@ function nameForMetadata(metadataJSON) {
 }
 
 function displayReviews(json) {
-  var html = '<h4>Reviews</h4>';
+  var html = `<h4>${l10n.reviews}:</h4>`;
 
   if (json.reviews.length == 0) {
     html += '<p>No reviews yet.</p>';

--- a/site-feature.js
+++ b/site-feature.js
@@ -243,6 +243,8 @@ function f2html(fdata) {
     ihtml = ihtml + '\n<div id="review" class="review_button">\n<a href="' + mangrove_url + '" target="_blank">' + l10n.review + ' (Mangrove)</a></div>'
   }
 
+  ihtml += '\n<div id="reviews_container"></div>';
+
   document.getElementById('info content').innerHTML = ihtml;
 }
 

--- a/site-feature.js
+++ b/site-feature.js
@@ -236,13 +236,6 @@ function f2html(fdata) {
     ihtml = ihtml + '</table></p>'
   }
 
-  // external review links
-  if ("name" in fdata.properties) {
-    mangrove_url='https://mangrove.reviews/search?sub=' + encodeURIComponent('geo:' + fdata.geometry.coordinates[1] + ',' + fdata.geometry.coordinates[0] + '?q=' + fdata.properties.name + '&u=30');
-    //console.log(mangrove_url);
-    ihtml = ihtml + '\n<div id="review" class="review_button">\n<a href="' + mangrove_url + '" target="_blank">' + l10n.add_review + ' (Mangrove)</a></div>'
-  }
-
   ihtml += '\n<div id="reviews_container"></div>';
 
   document.getElementById('info content').innerHTML = ihtml;

--- a/site-feature.js
+++ b/site-feature.js
@@ -240,7 +240,7 @@ function f2html(fdata) {
   if ("name" in fdata.properties) {
     mangrove_url='https://mangrove.reviews/search?sub=' + encodeURIComponent('geo:' + fdata.geometry.coordinates[1] + ',' + fdata.geometry.coordinates[0] + '?q=' + fdata.properties.name + '&u=30');
     //console.log(mangrove_url);
-    ihtml = ihtml + '\n<div id="review" class="review_button">\n<a href="' + mangrove_url + '" target="_blank">' + l10n.review + ' (Mangrove)</a></div>'
+    ihtml = ihtml + '\n<div id="review" class="review_button">\n<a href="' + mangrove_url + '" target="_blank">' + l10n.add_review + ' (Mangrove)</a></div>'
   }
 
   ihtml += '\n<div id="reviews_container"></div>';


### PR DESCRIPTION
With this branch, the reviews for a camp site are retrieved from Mangrove when the user selects a camp site on the map.

It still requires some testing (especially edge cases, such as multiple camp sites near each other, camp sites without any reviews), but the rough idea can already be seen.

Here's a screenshot of the feature in action:

<img width="408" alt="Screenshot 2022-08-03 at 13 24 18" src="https://user-images.githubusercontent.com/1681085/182597106-56621525-7f38-48b5-8af9-ffa1f089a8a6.png">
