### PR TITLE
No Ticket: Make phone number tappable

### DIFF
--- a/site-feature.js
+++ b/site-feature.js
@@ -168,9 +168,7 @@ function f2html(fdata) {
     ihtml = ihtml + '<b>' + l10n.email + ': </b>' + genmailto(fdata.properties['email']) + '<br />';
   }
 
-  if ("phone" in fdata.properties) {
-    ihtml = ihtml + '<b>' + l10n.phone + ': </b>' + fdata.properties['phone'] + '<br />';
-  }
+  ihtml += phoneNumberHTML(fdata);
 
   if ("fax" in fdata.properties) {
     ihtml = ihtml + '<b>' + l10n.fax + ': </b>' + fdata.properties['fax'] + '<br />';
@@ -244,6 +242,15 @@ function f2html(fdata) {
   }
 
   document.getElementById('info content').innerHTML = ihtml;
+}
+
+function phoneNumberHTML(featureData) {
+  if (!("phone" in featureData.properties)) {
+    // Without the phone number, there is nothing we want to display.
+    return '';
+  }
+
+  return '<b>' + l10n.phone + ': </b>' + featureData.properties['phone'] + '<br />';
 }
 
 /* build "bugs info" HTML for sidebar from json features */

--- a/site-feature.js
+++ b/site-feature.js
@@ -252,7 +252,13 @@ function phoneNumberHTML(featureData) {
 
   const tagValue = featureData.properties['phone'];
 
-  return `<b>${l10n.phone}:</b> ${tagValue}<br />`;
+  // According to the wiki, the tag might contain multiple phone numbers, separated by a semicolon.
+  const phoneNumbers = tagValue.split(';');
+  const phoneNumberLinks = phoneNumbers
+    .map((number) => `<a href="tel:${number}">${number}</a>`)
+    .join(', ');
+
+  return `<b>${l10n.phone}:</b> ${phoneNumberLinks}<br />`;
 }
 
 /* build "bugs info" HTML for sidebar from json features */

--- a/site-feature.js
+++ b/site-feature.js
@@ -250,7 +250,9 @@ function phoneNumberHTML(featureData) {
     return '';
   }
 
-  return '<b>' + l10n.phone + ': </b>' + featureData.properties['phone'] + '<br />';
+  const tagValue = featureData.properties['phone'];
+
+  return `<b>${l10n.phone}:</b> ${tagValue}<br />`;
 }
 
 /* build "bugs info" HTML for sidebar from json features */


### PR DESCRIPTION
With this branch, the phone number becomes tappable, meaning users can start a call with a click of a link. In addition, the branch adds support for multiple phone numbers for the `phone` tag (see [Key:phone](https://wiki.openstreetmap.org/wiki/Key:phone#Parsing_phone_numbers)).

| Before | After |
| --- | --- |
| <img width="391" alt="Screenshot 2022-08-03 at 23 42 57" src="https://user-images.githubusercontent.com/1681085/182718188-1c2ee999-579a-4415-a88f-0bb6008f694c.png"> | <img width="375" alt="Screenshot 2022-08-03 at 23 43 06" src="https://user-images.githubusercontent.com/1681085/182718209-d5c9a26b-75ab-4f12-8025-b2fd42b951b4.png"> |

The camping site above can be found here: https://camping.openstreetmap.de/map-dev/#19/49.85999/10.91627/4/1/bef