### PR TITLE
Add support for changeset hashtags

### DIFF
--- a/site-feature.js
+++ b/site-feature.js
@@ -1,5 +1,8 @@
 /* build "site info" HTML for sidebar from json features */
 
+// Hashtags with which the changesets in iD are getting pre-populated.
+let hashtags = ['#OpenCampingMap'];
+
 function genlink(url, text) {
   if (typeof text === "undefined") {
     text = url;
@@ -459,7 +462,8 @@ function editInID(fdata) {
 
   // Parameters for the "hash portion" of the URL (after the `#`)
   let hashURLParameters = [
-    `map=${map.getZoom()}/${fdata.geometry['coordinates'][1]}/${fdata.geometry['coordinates'][0]}`
+    `map=${map.getZoom()}/${fdata.geometry['coordinates'][1]}/${fdata.geometry['coordinates'][0]}`,
+    `hashtags=${hashtags.map(tag => encodeURIComponent(tag)).join(',')}`
   ];
 
   let url = `https://www.openstreetmap.org/edit?${queryParameters.join('&')}/#${hashURLParameters.join('&')}`;

--- a/site-feature.js
+++ b/site-feature.js
@@ -449,12 +449,18 @@ function editInJOSM(fdata) {
 function editInID(fdata) {
   let osm_id = fdata['id'].split('/');
 
+  // Parameters for the URL's query (after the '?')
+  let queryParameters = [
+    'editor=id',
+    `${osm_id[osm_id.length - 2]}=${osm_id[osm_id.length - 1]}`
+  ];
+
   // Parameters for the "hash portion" of the URL (after the `#`)
   let hashURLParameters = [
     `map=${map.getZoom()}/${fdata.geometry['coordinates'][1]}/${fdata.geometry['coordinates'][0]}`
   ];
 
-  let url = `https://www.openstreetmap.org/edit?editor=id&${osm_id[osm_id.length - 2]}=${osm_id[osm_id.length - 1]}/#${hashURLParameters.join('&')}`;
+  let url = `https://www.openstreetmap.org/edit?${queryParameters.join('&')}/#${hashURLParameters.join('&')}`;
 
   var win = window.open(url, '_blank');
 }

--- a/site-feature.js
+++ b/site-feature.js
@@ -447,7 +447,7 @@ function editInJOSM(fdata) {
 }
 
 function editInID(fdata) {
-  var osm_id = fdata['id'].split('/');
+  let osm_id = fdata['id'].split('/');
   var url = "https://www.openstreetmap.org/edit?editor=id&lon=" + fdata.geometry['coordinates'][0];
   url += "&lat=" + fdata.geometry['coordinates'][1] + "&zoom=" + map.getZoom() + "&" + osm_id[osm_id.length - 2] + "=" + osm_id[osm_id.length - 1];;
   var win = window.open(url, '_blank');

--- a/site-feature.js
+++ b/site-feature.js
@@ -448,7 +448,7 @@ function editInJOSM(fdata) {
 
 function editInID(fdata) {
   let osm_id = fdata['id'].split('/');
-  var url = "https://www.openstreetmap.org/edit?editor=id&lon=" + fdata.geometry['coordinates'][0];
-  url += "&lat=" + fdata.geometry['coordinates'][1] + "&zoom=" + map.getZoom() + "&" + osm_id[osm_id.length - 2] + "=" + osm_id[osm_id.length - 1];;
+  let url = `https://www.openstreetmap.org/edit?editor=id&${osm_id[osm_id.length - 2]}=${osm_id[osm_id.length - 1]}/#map=${map.getZoom()}/${fdata.geometry['coordinates'][1]}/${fdata.geometry['coordinates'][0]}`;
+
   var win = window.open(url, '_blank');
 }

--- a/site-feature.js
+++ b/site-feature.js
@@ -448,11 +448,13 @@ function editInJOSM(fdata) {
 
 function editInID(fdata) {
   let osm_id = fdata['id'].split('/');
+  let osmObjectType = osm_id[osm_id.length - 2];
+  let osmObjectId = osm_id[osm_id.length - 1];
 
   // Parameters for the URL's query (after the '?')
   let queryParameters = [
     'editor=id',
-    `${osm_id[osm_id.length - 2]}=${osm_id[osm_id.length - 1]}`
+    `${osmObjectType}=${osmObjectId}`
   ];
 
   // Parameters for the "hash portion" of the URL (after the `#`)

--- a/site-feature.js
+++ b/site-feature.js
@@ -448,7 +448,13 @@ function editInJOSM(fdata) {
 
 function editInID(fdata) {
   let osm_id = fdata['id'].split('/');
-  let url = `https://www.openstreetmap.org/edit?editor=id&${osm_id[osm_id.length - 2]}=${osm_id[osm_id.length - 1]}/#map=${map.getZoom()}/${fdata.geometry['coordinates'][1]}/${fdata.geometry['coordinates'][0]}`;
+
+  // Parameters for the "hash portion" of the URL (after the `#`)
+  let hashURLParameters = [
+    `map=${map.getZoom()}/${fdata.geometry['coordinates'][1]}/${fdata.geometry['coordinates'][0]}`
+  ];
+
+  let url = `https://www.openstreetmap.org/edit?editor=id&${osm_id[osm_id.length - 2]}=${osm_id[osm_id.length - 1]}/#${hashURLParameters.join('&')}`;
 
   var win = window.open(url, '_blank');
 }


### PR DESCRIPTION
With this branch, changesets in iD are pre-populated with the hashtag `#OpenCampingMap` when clicking the "Edit in iD" button.

![changeset-hashtags](https://user-images.githubusercontent.com/1681085/185488554-24958583-3743-4b83-9cf6-a8fea511d558.png)

While working on this task, I have taken the liberty to make the method a bit more readable and easier to maintain and extend.