### PR TITLE
Add support for hashtags in JOSM (#14)

### DIFF
--- a/site-feature.js
+++ b/site-feature.js
@@ -443,6 +443,9 @@ function editInJOSM(fdata) {
     bbox[2] + '&top=' + bbox[3] + '&bottom=' + bbox[1];
   url += '&select=' + osm_id[osm_id.length - 2] + osm_id[osm_id.length - 1];
 
+  let encodedWhiteSpace = encodeURIComponent(' ');
+  url += `&changeset_hashtags=${hashtags.map(tag => encodeURIComponent(tag)).join(encodedWhiteSpace)}`;
+
   // call remote control command, ignore response        
   var request = new XMLHttpRequest();
   request.open("GET", url);


### PR DESCRIPTION
This branch adds support for hashtags when editing a camping site in JOSM.

<img width="732" alt="josm-hashtags" src="https://user-images.githubusercontent.com/1681085/185746813-c5b1d01b-d459-4feb-9aaf-4632f4a5e014.png">