### PR TITLE
Handle ratings that cannot be divided by 20 without a remainder

### DIFF
--- a/js/reviews.js
+++ b/js/reviews.js
@@ -76,6 +76,9 @@ function starsForRating(rating) {
   let fullStar = '★';
 
   let numberOfFullStars = Math.round(rating / 20);
+  if (numberOfFullStars * 20 < rating) {
+    numberOfFullStars++;
+  }
   let numberOfEmptyStars = 5 - numberOfFullStars;
 
   return `${fullStar.repeat(numberOfFullStars)}${emptyStar.repeat(numberOfEmptyStars)}`;


### PR DESCRIPTION
This fixes #56 and brings the display of the rating in line with Mangrove's UI.